### PR TITLE
Fix typos and improve query time handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ A Next.js-based MCP (Model Context Protocol) server that provides opportunity zo
 3. **Set up the database**:
    ```bash
    npx prisma migrate deploy
-   npm run seed:opportunity-zones
+   npm run seed
    ```
 
 4. **Start the development server**:

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "preprocess:force": "node scripts/preprocess-opportunity-zones.js --force",
     "optimize": "npm run preprocess && npm run seed",
     "deploy:setup": "node scripts/deploy-setup.js",
-    "postinstall": "prisma generate"
+    "postinstall": "prisma generate",
+    "test": "node --test"
   },
   "dependencies": {
     "@auth/core": "^0.39.1",

--- a/scripts/preprocess-opportunity-zones.js
+++ b/scripts/preprocess-opportunity-zones.js
@@ -170,7 +170,7 @@ class OpportunityZonePreprocessor {
         type: 'Feature',
         geometry: this.optimizeGeometry(feature.geometry),
         properties: {
-          GEOID: feature.properties?.GEOID || feature.properties?.CENSUSTRAC || `OZ_${i}`
+          GEOID: feature.properties?.GEOID || feature.properties?.CENSUSTRACT || `OZ_${i}`
         }
       };
 

--- a/scripts/seed-opportunity-zones-postgis.js
+++ b/scripts/seed-opportunity-zones-postgis.js
@@ -183,7 +183,7 @@ class PostGISOpportunityZoneSeeder extends OpportunityZoneSeeder {
         this.log('info', `📦 Processing batch ${Math.floor(i / batchSize) + 1}/${Math.ceil(features.length / batchSize)} (${batch.length} features)`);
         
         const batchPromises = batch.map(async (feature) => {
-          const geoid = feature.properties?.GEOID || feature.properties?.CENSUSTRAC;
+          const geoid = feature.properties?.GEOID || feature.properties?.CENSUSTRACT;
           
           if (!geoid) {
             this.log('warning', `⚠️  Skipping feature without GEOID`);

--- a/scripts/seed-opportunity-zones.js
+++ b/scripts/seed-opportunity-zones.js
@@ -68,7 +68,7 @@ class OpportunityZoneSeeder {
         type: 'Feature',
         geometry: feature.geometry,
         properties: {
-          GEOID: feature.properties?.GEOID || feature.properties?.CENSUSTRAC
+          GEOID: feature.properties?.GEOID || feature.properties?.CENSUSTRACT
         }
       }))
     };

--- a/src/app/api/opportunity-zones/check/route.ts
+++ b/src/app/api/opportunity-zones/check/route.ts
@@ -280,6 +280,7 @@ export async function GET(request: NextRequest) {
     }
   }
 
+  const startTime = Date.now()
   try {
     // If address is provided, handle geocoding and usage validation
     if (address) {
@@ -342,7 +343,6 @@ export async function GET(request: NextRequest) {
     }
 
     const service = OpportunityZoneService.getInstance()
-    const startTime = Date.now()
 
     const result = await service.checkPoint(latitude, longitude)
     const queryTime = Date.now() - startTime
@@ -490,7 +490,7 @@ export async function GET(request: NextRequest) {
     
     return finalResponse
   } catch (error) {
-    const queryTime = Date.now() - (Date.now() - 100) // Approximate timing for error case
+    const queryTime = Date.now() - startTime
     
     console.error('Error checking opportunity zone:', error)
     

--- a/src/lib/services/postgis-opportunity-zones.ts
+++ b/src/lib/services/postgis-opportunity-zones.ts
@@ -149,7 +149,7 @@ export class PostGISOpportunityZoneService {
         log("info", `📦 Processing batch ${Math.floor(i / batchSize) + 1}/${Math.ceil(features.length / batchSize)} (${batch.length} features)`)
         
         const batchPromises = batch.map(async (feature: any) => {
-          const geoid = feature.properties?.GEOID || feature.properties?.CENSUSTRAC
+          const geoid = feature.properties?.GEOID || feature.properties?.CENSUSTRACT
           
           if (!geoid) {
             log("warning", `⚠️  Skipping feature without GEOID`)

--- a/tests/geocoding.test.ts
+++ b/tests/geocoding.test.ts
@@ -1,0 +1,34 @@
+import { test, strictEqual } from 'node:test'
+import { GeocodingService } from '../src/lib/services/geocoding'
+import { prisma } from '../src/app/prisma'
+
+// Simple in-memory cache mock
+const cache: Record<string, any> = {}
+prisma.geocodingCache = {
+  findUnique: async ({ where }: any) => cache[where.address] || null,
+  upsert: async ({ where, update, create }: any) => {
+    cache[where.address] = { id: 1, ...(create || {}), ...(update || {}) }
+  }
+} as any
+
+// Mock fetch to record calls
+let fetchCount = 0
+;(global as any).fetch = async () => {
+  fetchCount++
+  return {
+    ok: true,
+    json: async () => [{ lat: '1', lon: '2', display_name: 'Mock Address' }]
+  } as any
+}
+
+const service = GeocodingService.getInstance()
+
+test('geocodeAddress caches results', async () => {
+  const addr = '123 Test St'
+  const first = await service.geocodeAddress(addr)
+  const second = await service.geocodeAddress(addr)
+
+  strictEqual(fetchCount, 1)
+  strictEqual(first.latitude, second.latitude)
+  strictEqual(first.longitude, second.longitude)
+})


### PR DESCRIPTION
## Summary
- correct property name `CENSUSTRACT`
- fix query time measurement on OZ check endpoint
- update README quick start
- add minimal geocoding cache test using Node's test runner
- expose `npm test` script

## Testing
- `npm test` *(fails: no tests executed)*

------
https://chatgpt.com/codex/tasks/task_e_687837c4483883279636767f767446a5