### PR TITLE
Add get listing address service and mcp tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,19 @@ Validate search parameters before making requests.
 ### `get_api_status`
 Get current API status and rate limiting information.
 
+### `get_listing_address`
+Extract a normalized street address from a listing URL.
+
+**Parameters:**
+- `url` (string): Listing URL to analyze
+
+**Example:**
+```typescript
+await use_mcp_tool("get_listing_address", {
+  url: "https://www.zillow.com/homedetails/123-Main-St-Somecity-ST-12345/1234567_zpid/"
+});
+```
+
 ## 🔐 OAuth 2.1 Implementation
 
 ### Authorization Flow
@@ -195,6 +208,7 @@ Key tables:
 
 - `GET /api/opportunity-zones/check` - Check coordinates
 - `POST /api/opportunity-zones/geocode` - Geocode address
+- `POST /api/listing-address` - Extract listing address from a URL
 - `GET /api/opportunity-zones/status` - API status
 - `POST /api/oauth/register` - Register OAuth client
 - `POST /api/oauth/token` - Exchange tokens

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,6 @@
         "@radix-ui/react-toast": "1.2.4",
         "@radix-ui/react-toggle": "1.1.1",
         "@radix-ui/react-toggle-group": "1.1.1",
-        "@radix-ui/react-tooltip": "1.1.6",
         "@turf/boolean-point-in-polygon": "^7.2.0",
         "@turf/helpers": "^7.2.0",
         "@vercel/analytics": "^1.1.1",
@@ -84,6 +83,7 @@
         "postcss": "^8.5.6",
         "prisma": "^6.10.1",
         "tailwindcss": "^3.4.17",
+        "tsx": "^4.19.2",
         "typescript": "^5"
       }
     },
@@ -203,6 +203,448 @@
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
       "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
       "license": "MIT"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.8.tgz",
+      "integrity": "sha512-urAvrUedIqEiFR3FYSLTWQgLu5tb+m0qZw0NBEasUeo6wuqatkMDaRT+1uABiGXEu5vqgPd7FGE1BhsAIy9QVA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.8.tgz",
+      "integrity": "sha512-RONsAvGCz5oWyePVnLdZY/HHwA++nxYWIX1atInlaW6SEkwq6XkP3+cb825EUcRs5Vss/lGh/2YxAb5xqc07Uw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.8.tgz",
+      "integrity": "sha512-OD3p7LYzWpLhZEyATcTSJ67qB5D+20vbtr6vHlHWSQYhKtzUYrETuWThmzFpZtFsBIxRvhO07+UgVA9m0i/O1w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.8.tgz",
+      "integrity": "sha512-yJAVPklM5+4+9dTeKwHOaA+LQkmrKFX96BM0A/2zQrbS6ENCmxc4OVoBs5dPkCCak2roAD+jKCdnmOqKszPkjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.8.tgz",
+      "integrity": "sha512-Jw0mxgIaYX6R8ODrdkLLPwBqHTtYHJSmzzd+QeytSugzQ0Vg4c5rDky5VgkoowbZQahCbsv1rT1KW72MPIkevw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.8.tgz",
+      "integrity": "sha512-Vh2gLxxHnuoQ+GjPNvDSDRpoBCUzY4Pu0kBqMBDlK4fuWbKgGtmDIeEC081xi26PPjn+1tct+Bh8FjyLlw1Zlg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.8.tgz",
+      "integrity": "sha512-YPJ7hDQ9DnNe5vxOm6jaie9QsTwcKedPvizTVlqWG9GBSq+BuyWEDazlGaDTC5NGU4QJd666V0yqCBL2oWKPfA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.8.tgz",
+      "integrity": "sha512-MmaEXxQRdXNFsRN/KcIimLnSJrk2r5H8v+WVafRWz5xdSVmWLoITZQXcgehI2ZE6gioE6HirAEToM/RvFBeuhw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.8.tgz",
+      "integrity": "sha512-FuzEP9BixzZohl1kLf76KEVOsxtIBFwCaLupVuk4eFVnOZfU+Wsn+x5Ryam7nILV2pkq2TqQM9EZPsOBuMC+kg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.8.tgz",
+      "integrity": "sha512-WIgg00ARWv/uYLU7lsuDK00d/hHSfES5BzdWAdAig1ioV5kaFNrtK8EqGcUBJhYqotlUByUKz5Qo6u8tt7iD/w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.8.tgz",
+      "integrity": "sha512-A1D9YzRX1i+1AJZuFFUMP1E9fMaYY+GnSQil9Tlw05utlE86EKTUA7RjwHDkEitmLYiFsRd9HwKBPEftNdBfjg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.8.tgz",
+      "integrity": "sha512-O7k1J/dwHkY1RMVvglFHl1HzutGEFFZ3kNiDMSOyUrB7WcoHGf96Sh+64nTRT26l3GMbCW01Ekh/ThKM5iI7hQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.8.tgz",
+      "integrity": "sha512-uv+dqfRazte3BzfMp8PAQXmdGHQt2oC/y2ovwpTteqrMx2lwaksiFZ/bdkXJC19ttTvNXBuWH53zy/aTj1FgGw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.8.tgz",
+      "integrity": "sha512-GyG0KcMi1GBavP5JgAkkstMGyMholMDybAf8wF5A70CALlDM2p/f7YFE7H92eDeH/VBtFJA5MT4nRPDGg4JuzQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.8.tgz",
+      "integrity": "sha512-rAqDYFv3yzMrq7GIcen3XP7TUEG/4LK86LUPMIz6RT8A6pRIDn0sDcvjudVZBiiTcZCY9y2SgYX2lgK3AF+1eg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.8.tgz",
+      "integrity": "sha512-Xutvh6VjlbcHpsIIbwY8GVRbwoviWT19tFhgdA7DlenLGC/mbc3lBoVb7jxj9Z+eyGqvcnSyIltYUrkKzWqSvg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.8.tgz",
+      "integrity": "sha512-ASFQhgY4ElXh3nDcOMTkQero4b1lgubskNlhIfJrsH5OKZXDpUAKBlNS0Kx81jwOBp+HCeZqmoJuihTv57/jvQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.8.tgz",
+      "integrity": "sha512-d1KfruIeohqAi6SA+gENMuObDbEjn22olAR7egqnkCD9DGBG0wsEARotkLgXDu6c4ncgWTZJtN5vcgxzWRMzcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.8.tgz",
+      "integrity": "sha512-nVDCkrvx2ua+XQNyfrujIG38+YGyuy2Ru9kKVNyh5jAys6n+l44tTtToqHjino2My8VAY6Lw9H7RI73XFi66Cg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.8.tgz",
+      "integrity": "sha512-j8HgrDuSJFAujkivSMSfPQSAa5Fxbvk4rgNAS5i3K+r8s1X0p1uOO2Hl2xNsGFppOeHOLAVgYwDVlmxhq5h+SQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.8.tgz",
+      "integrity": "sha512-1h8MUAwa0VhNCDp6Af0HToI2TJFAn1uqT9Al6DJVzdIBAd21m/G0Yfc77KDM3uF3T/YaOgQq3qTJHPbTOInaIQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.8.tgz",
+      "integrity": "sha512-r2nVa5SIK9tSWd0kJd9HCffnDHKchTGikb//9c7HX+r+wHYCpQrSgxhlY6KWV1nFo1l4KFbsMlHk+L6fekLsUg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.8.tgz",
+      "integrity": "sha512-zUlaP2S12YhQ2UzUfcCuMDHQFJyKABkAjvO5YSndMiIkMimPmxA+BYSBikWgsRpvyxuRnow4nS5NPnf9fpv41w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.8.tgz",
+      "integrity": "sha512-YEGFFWESlPva8hGL+zvj2z/SaK+pH0SwOM0Nc/d+rVnW7GSTFlLBGzZkuSU9kFIGIo8q9X3ucpZhu8PDN5A2sQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.8.tgz",
+      "integrity": "sha512-hiGgGC6KZ5LZz58OL/+qVVoZiuZlUYlYHNAmczOm7bs2oE1XriPFi5ZHHrS8ACpV5EjySrnoCKmcbQMN+ojnHg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.8.tgz",
+      "integrity": "sha512-cn3Yr7+OaaZq1c+2pe+8yxC8E144SReCQjN6/2ynubzYjvyqZjTXfQJpAcQpsdJq3My7XADANiYGHoFC69pLQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@floating-ui/core": {
       "version": "1.7.2",
@@ -2137,40 +2579,6 @@
         }
       }
     },
-    "node_modules/@radix-ui/react-tooltip": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.1.6.tgz",
-      "integrity": "sha512-TLB5D8QLExS1uDn7+wH/bjEmRurNMTzNrtq7IjaS4kjion9NtzsTGkvR5+i7yc9q01Pi2KMM2cN3f8UG4IvvXA==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/primitive": "1.1.1",
-        "@radix-ui/react-compose-refs": "1.1.1",
-        "@radix-ui/react-context": "1.1.1",
-        "@radix-ui/react-dismissable-layer": "1.1.3",
-        "@radix-ui/react-id": "1.1.0",
-        "@radix-ui/react-popper": "1.2.1",
-        "@radix-ui/react-portal": "1.1.3",
-        "@radix-ui/react-presence": "1.1.2",
-        "@radix-ui/react-primitive": "2.0.1",
-        "@radix-ui/react-slot": "1.1.1",
-        "@radix-ui/react-use-controllable-state": "1.1.0",
-        "@radix-ui/react-visually-hidden": "1.1.1"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@radix-ui/react-use-callback-ref": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.0.tgz",
@@ -3512,6 +3920,48 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.8.tgz",
+      "integrity": "sha512-vVC0USHGtMi8+R4Kz8rt6JhEWLxsv9Rnu/lGYbPR8u47B+DCBksq9JarW0zOO7bs37hyOK1l2/oqtbciutL5+Q==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.8",
+        "@esbuild/android-arm": "0.25.8",
+        "@esbuild/android-arm64": "0.25.8",
+        "@esbuild/android-x64": "0.25.8",
+        "@esbuild/darwin-arm64": "0.25.8",
+        "@esbuild/darwin-x64": "0.25.8",
+        "@esbuild/freebsd-arm64": "0.25.8",
+        "@esbuild/freebsd-x64": "0.25.8",
+        "@esbuild/linux-arm": "0.25.8",
+        "@esbuild/linux-arm64": "0.25.8",
+        "@esbuild/linux-ia32": "0.25.8",
+        "@esbuild/linux-loong64": "0.25.8",
+        "@esbuild/linux-mips64el": "0.25.8",
+        "@esbuild/linux-ppc64": "0.25.8",
+        "@esbuild/linux-riscv64": "0.25.8",
+        "@esbuild/linux-s390x": "0.25.8",
+        "@esbuild/linux-x64": "0.25.8",
+        "@esbuild/netbsd-arm64": "0.25.8",
+        "@esbuild/netbsd-x64": "0.25.8",
+        "@esbuild/openbsd-arm64": "0.25.8",
+        "@esbuild/openbsd-x64": "0.25.8",
+        "@esbuild/openharmony-arm64": "0.25.8",
+        "@esbuild/sunos-x64": "0.25.8",
+        "@esbuild/win32-arm64": "0.25.8",
+        "@esbuild/win32-ia32": "0.25.8",
+        "@esbuild/win32-x64": "0.25.8"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -3865,6 +4315,19 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
+      "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/glob": {
@@ -5440,6 +5903,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -6097,6 +6570,26 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.20.3",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.3.tgz",
+      "integrity": "sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-is": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "optimize": "npm run preprocess && npm run seed",
     "deploy:setup": "node scripts/deploy-setup.js",
     "postinstall": "prisma generate",
-    "test": "node --test"
+    "test": "tsx --test \"tests/**/*.test.ts\""
   },
   "dependencies": {
     "@auth/core": "^0.39.1",
@@ -51,7 +51,6 @@
     "@radix-ui/react-toast": "1.2.4",
     "@radix-ui/react-toggle": "1.1.1",
     "@radix-ui/react-toggle-group": "1.1.1",
-    "@radix-ui/react-tooltip": "1.1.6",
     "@turf/boolean-point-in-polygon": "^7.2.0",
     "@turf/helpers": "^7.2.0",
     "@vercel/analytics": "^1.1.1",
@@ -94,6 +93,7 @@
     "postcss": "^8.5.6",
     "prisma": "^6.10.1",
     "tailwindcss": "^3.4.17",
+    "tsx": "^4.19.2",
     "typescript": "^5"
   }
 }

--- a/src/app/api/listing-address/route.ts
+++ b/src/app/api/listing-address/route.ts
@@ -1,0 +1,84 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { extractAddressFromUrl } from '@/lib/services/listing-address'
+
+export const runtime = 'nodejs'
+
+const requestSchema = z.object({
+  url: z.string().url('Invalid URL')
+})
+
+export async function OPTIONS() {
+  return new NextResponse(null, {
+    status: 204,
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'POST, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+    }
+  })
+}
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json().catch(() => null)
+    const parsed = requestSchema.safeParse(body)
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          error: 'Invalid request parameters',
+          details: parsed.error.format()
+        },
+        {
+          status: 400,
+          headers: {
+            'Access-Control-Allow-Origin': '*',
+          }
+        }
+      )
+    }
+
+    const { url } = parsed.data
+
+    const address = await extractAddressFromUrl(url)
+
+    return NextResponse.json(
+      { address },
+      {
+        status: 200,
+        headers: {
+          'Access-Control-Allow-Origin': '*',
+          'Cache-Control': 'no-store',
+        }
+      }
+    )
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error'
+    if (message === 'NOT_FOUND') {
+      return NextResponse.json(
+        { error: 'Address not found' },
+        {
+          status: 422,
+          headers: {
+            'Access-Control-Allow-Origin': '*',
+          }
+        }
+      )
+    }
+
+    console.error('Error extracting listing address:', error)
+    return NextResponse.json(
+      {
+        error: 'Server error',
+        message
+      },
+      {
+        status: 500,
+        headers: {
+          'Access-Control-Allow-Origin': '*',
+        }
+      }
+    )
+  }
+}

--- a/src/lib/services/listing-address.ts
+++ b/src/lib/services/listing-address.ts
@@ -1,0 +1,230 @@
+// Type for the log function
+export type LogFn = (type: "info" | "success" | "warning" | "error", message: string) => void;
+
+const defaultLog: LogFn = (type, message) => {
+  console.log(`[${type.toUpperCase()}] ${message}`)
+};
+
+interface ParsedAddress {
+  street: string
+  city: string
+  state: string
+  zip: string
+}
+
+function toTitleCase(input: string): string {
+  return input
+    .split(/\s+/)
+    .map(part => {
+      if (/^(N|S|E|W|NE|NW|SE|SW)$/.test(part)) return part; // cardinal directions
+      if (part.toUpperCase() === part) return part; // already upper (e.g., state)
+      return part.charAt(0).toUpperCase() + part.slice(1).toLowerCase();
+    })
+    .join(' ')
+    .replace(/\s+/g, ' ') // collapse extra spaces
+    .trim();
+}
+
+function normalizeSeparators(text: string): string {
+  return decodeURIComponent(text)
+    .replace(/[+_]/g, ' ')
+    .replace(/-/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function formatAddress(addr: ParsedAddress): string {
+  const street = toTitleCase(addr.street.trim());
+  const city = toTitleCase(addr.city.trim());
+  const state = addr.state.trim().toUpperCase();
+  const zip = addr.zip.trim();
+  return `${street}, ${city}, ${state} ${zip}`;
+}
+
+function validateFinalAddress(address: string): boolean {
+  // Stricter validation: 123 Main St, Some City, ST 12345(-6789)
+  const strict = /^\d{1,6}\s+[^,]+,\s*[A-Za-z.'’&\-\s]+,\s*[A-Z]{2}\s+\d{5}(?:-\d{4})?$/;
+  return strict.test(address);
+}
+
+function extractUsingRegex(text: string): ParsedAddress | null {
+  const cleaned = normalizeSeparators(text);
+  const addressRegex = /(\d{1,6}\s+[A-Za-z0-9.'’&\- ]+?\s+(?:St(?:reet)?|Ave(?:nue)?|Rd|Road|Blvd|Boulevard|Dr|Drive|Ct|Court|Ln|Lane|Way|Pl|Place|Cir|Circle|Pkwy|Parkway|Ter|Terrace|Trl|Trail|Hwy|Highway|Pike|Row|Sq|Square|Loop|Run|Cres|Crescent|Bend|Rte|Route)\b(?:\s+(?:N|S|E|W|NE|NW|SE|SW|North|South|East|West))?)\s*,?\s*([A-Za-z.'’&\- ]+?),?\s+([A-Z]{2})\s+(\d{5}(?:-\d{4})?)/i;
+  const match = cleaned.match(addressRegex);
+  if (!match) return null;
+  const [, street, city, state, zip] = match;
+  return { street, city, state, zip };
+}
+
+function extractFromJsonLd(html: string): ParsedAddress | null {
+  const scriptRegex = /<script[^>]+type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi;
+  let m: RegExpExecArray | null;
+  while ((m = scriptRegex.exec(html)) !== null) {
+    const raw = m[1].trim();
+    if (!raw) continue;
+    try {
+      const parsed = JSON.parse(raw);
+      const found = findPostalAddress(parsed);
+      if (found) return found;
+    } catch {
+      // ignore parse errors
+    }
+  }
+  return null;
+}
+
+function findPostalAddress(node: any): ParsedAddress | null {
+  if (!node || typeof node !== 'object') return null;
+
+  const tryNode = (obj: any): ParsedAddress | null => {
+    if (!obj || typeof obj !== 'object') return null;
+    const addr = obj.address || (obj['@type'] && obj['@type'] === 'PostalAddress' ? obj : null);
+    const addressObj = addr && !addr['@type'] ? addr : (obj['@type'] === 'PostalAddress' ? obj : null);
+    const candidate = addressObj || addr;
+    if (candidate && typeof candidate === 'object') {
+      const street = candidate.streetAddress;
+      const city = candidate.addressLocality;
+      const state = candidate.addressRegion;
+      const zip = candidate.postalCode;
+      const country = candidate.addressCountry;
+      if (street && city && state && zip && (!country || /^(US|USA|United States)$/i.test(country))) {
+        return { street, city, state, zip };
+      }
+    }
+    return null;
+  };
+
+  // Direct match on node
+  const direct = tryNode(node);
+  if (direct) return direct;
+
+  // If array, search elements
+  if (Array.isArray(node)) {
+    for (const item of node) {
+      const r = findPostalAddress(item);
+      if (r) return r;
+    }
+    return null;
+  }
+
+  // Otherwise, search object properties
+  for (const key of Object.keys(node)) {
+    const r = findPostalAddress(node[key]);
+    if (r) return r;
+  }
+  return null;
+}
+
+function extractFromMetaTags(html: string): ParsedAddress | null {
+  const metas: Record<string, string> = {};
+  const metaRegex = /<meta[^>]+(?:property|name)=["']([^"']+)["'][^>]*content=["']([^"']+)["'][^>]*>/gi;
+  let m: RegExpExecArray | null;
+  while ((m = metaRegex.exec(html)) !== null) {
+    const name = m[1].toLowerCase();
+    const content = m[2];
+    metas[name] = content;
+  }
+  const street = metas['og:street-address'] || metas['street-address'] || metas['address'] || '';
+  const city = metas['og:locality'] || metas['locality'] || '';
+  const state = metas['og:region'] || metas['region'] || '';
+  const zip = metas['og:postal-code'] || metas['postal-code'] || '';
+  if (street && city && state && zip) return { street, city, state, zip };
+  return null;
+}
+
+function stripHtml(html: string): string {
+  return html.replace(/<script[\s\S]*?<\/script>/gi, '')
+             .replace(/<style[\s\S]*?<\/style>/gi, '')
+             .replace(/<[^>]+>/g, ' ');
+}
+
+async function fetchHtml(url: string, log: LogFn): Promise<string> {
+  log('info', `Fetching HTML for ${url}`);
+  const response = await fetch(url, {
+    headers: {
+      'User-Agent': 'Opportunity Zone MCP Server',
+      'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8'
+    }
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to fetch page: ${response.status} ${response.statusText}`);
+  }
+  return await response.text();
+}
+
+function tryExtractFromUrl(u: URL, log: LogFn): ParsedAddress | null {
+  const joined = [u.pathname, u.search, u.hash].filter(Boolean).join(' ');
+  const parsed = extractUsingRegex(joined);
+  if (parsed) {
+    log('success', 'Extracted address from URL');
+    return parsed;
+  }
+  // Try again on normalized separators
+  const normalized = normalizeSeparators(joined);
+  const parsed2 = extractUsingRegex(normalized);
+  if (parsed2) {
+    log('success', 'Extracted address from URL (normalized)');
+    return parsed2;
+  }
+  return null;
+}
+
+export async function extractAddressFromUrl(listingUrl: string, log: LogFn = defaultLog): Promise<string> {
+  if (!listingUrl || typeof listingUrl !== 'string') {
+    throw new Error('Invalid URL');
+  }
+
+  let url: URL;
+  try {
+    url = new URL(listingUrl);
+  } catch {
+    throw new Error('Invalid URL');
+  }
+  if (!/^https?:$/.test(url.protocol)) {
+    throw new Error('Invalid URL');
+  }
+
+  // 1) Try parsing from URL itself
+  const fromUrl = tryExtractFromUrl(url, log);
+  if (fromUrl) {
+    const formatted = formatAddress(fromUrl);
+    if (validateFinalAddress(formatted)) {
+      return formatted;
+    }
+  }
+
+  // 2) Fetch HTML and try JSON-LD, Meta, then text fallback
+  const html = await fetchHtml(url.href, log);
+
+  const fromJsonLd = extractFromJsonLd(html);
+  if (fromJsonLd) {
+    const formatted = formatAddress(fromJsonLd);
+    if (validateFinalAddress(formatted)) {
+      log('success', 'Extracted address from JSON-LD');
+      return formatted;
+    }
+  }
+
+  const fromMeta = extractFromMetaTags(html);
+  if (fromMeta) {
+    const formatted = formatAddress(fromMeta);
+    if (validateFinalAddress(formatted)) {
+      log('success', 'Extracted address from meta tags');
+      return formatted;
+    }
+  }
+
+  const text = stripHtml(html);
+  const fromText = extractUsingRegex(text);
+  if (fromText) {
+    const formatted = formatAddress(fromText);
+    if (validateFinalAddress(formatted)) {
+      log('success', 'Extracted address from page text');
+      return formatted;
+    }
+  }
+
+  const err = new Error('NOT_FOUND');
+  (err as any).code = 'NOT_FOUND';
+  throw err;
+}

--- a/src/lib/services/listing-address.ts
+++ b/src/lib/services/listing-address.ts
@@ -49,7 +49,7 @@ function validateFinalAddress(address: string): boolean {
 
 function extractUsingRegex(text: string): ParsedAddress | null {
   const cleaned = normalizeSeparators(text);
-  const addressRegex = /(\d{1,6}\s+[A-Za-z0-9.'’&\- ]+?\s+(?:St(?:reet)?|Ave(?:nue)?|Rd|Road|Blvd|Boulevard|Dr|Drive|Ct|Court|Ln|Lane|Way|Pl|Place|Cir|Circle|Pkwy|Parkway|Ter|Terrace|Trl|Trail|Hwy|Highway|Pike|Row|Sq|Square|Loop|Run|Cres|Crescent|Bend|Rte|Route)\b(?:\s+(?:N|S|E|W|NE|NW|SE|SW|North|South|East|West))?)\s*,?\s*([A-Za-z.'’&\- ]+?),?\s+([A-Z]{2})\s+(\d{5}(?:-\d{4})?)/i;
+  const addressRegex = /(\d{1,6}\s+[A-Za-z0-9.'’&\- ]+?\s+(?:St(?:reet)?|Ave(?:nue)?|Rd|Road|Blvd|Boulevard|Dr|Drive|Ct|Court|Ln|Lane|Way|Pl|Place|Cir|Circle|Pkwy|Parkway|Ter|Terrace|Trl|Trail|Hwy|Highway|Pike|Row|Sq|Square|Loop|Run|Cres|Crescent|Bend|Rte|Route)\b)\s*,?\s*([A-Za-z.'’&\- ]+?),?\s+([A-Z]{2})\s+(\d{5}(?:-\d{4})?)(?![A-Za-z])/i;
   const match = cleaned.match(addressRegex);
   if (!match) return null;
   const [, street, city, state, zip] = match;

--- a/tests/geocoding.test.ts
+++ b/tests/geocoding.test.ts
@@ -1,15 +1,18 @@
-import { test, strictEqual } from 'node:test'
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
 import { GeocodingService } from '../src/lib/services/geocoding'
 import { prisma } from '../src/app/prisma'
 
+process.env.GEOCODING_API_KEY = process.env.GEOCODING_API_KEY || 'test'
+
 // Simple in-memory cache mock
 const cache: Record<string, any> = {}
-prisma.geocodingCache = {
+;(prisma as any).geocodingCache = {
   findUnique: async ({ where }: any) => cache[where.address] || null,
   upsert: async ({ where, update, create }: any) => {
     cache[where.address] = { id: 1, ...(create || {}), ...(update || {}) }
   }
-} as any
+}
 
 // Mock fetch to record calls
 let fetchCount = 0
@@ -28,7 +31,7 @@ test('geocodeAddress caches results', async () => {
   const first = await service.geocodeAddress(addr)
   const second = await service.geocodeAddress(addr)
 
-  strictEqual(fetchCount, 1)
-  strictEqual(first.latitude, second.latitude)
-  strictEqual(first.longitude, second.longitude)
+  assert.strictEqual(fetchCount, 1)
+  assert.strictEqual(first.latitude, second.latitude)
+  assert.strictEqual(first.longitude, second.longitude)
 })

--- a/tests/listingAddressService.test.ts
+++ b/tests/listingAddressService.test.ts
@@ -1,4 +1,5 @@
-import { test, strictEqual, rejects } from 'node:test'
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
 import { extractAddressFromUrl } from '../src/lib/services/listing-address'
 
 // Reset fetch between tests
@@ -12,7 +13,7 @@ test('extracts address from URL slug', async () => {
 
   const url = 'https://www.zillow.com/homedetails/123-Main-St-Somecity-ST-12345/1234567_zpid/'
   const address = await extractAddressFromUrl(url)
-  strictEqual(address, '123 Main St, Somecity, ST 12345')
+  assert.strictEqual(address, '123 Main St, Somecity, ST 12345')
 })
 
 test('extracts address from JSON-LD in HTML', async () => {
@@ -44,7 +45,7 @@ test('extracts address from JSON-LD in HTML', async () => {
 
   const url = 'https://example.com/listing/abc'
   const address = await extractAddressFromUrl(url)
-  strictEqual(address, '456 Oak Ave, Redwood City, CA 94063')
+  assert.strictEqual(address, '456 Oak Ave, Redwood City, CA 94063')
 })
 
 test('throws NOT_FOUND when no address is present', async () => {
@@ -56,7 +57,7 @@ test('throws NOT_FOUND when no address is present', async () => {
   }
 
   const url = 'https://example.com/listing/no-address'
-  await rejects(async () => extractAddressFromUrl(url))
+  await assert.rejects(async () => extractAddressFromUrl(url))
 })
 
 // Restore fetch after tests

--- a/tests/listingAddressService.test.ts
+++ b/tests/listingAddressService.test.ts
@@ -1,0 +1,63 @@
+import { test, strictEqual, rejects } from 'node:test'
+import { extractAddressFromUrl } from '../src/lib/services/listing-address'
+
+// Reset fetch between tests
+const originalFetch = global.fetch
+
+test('extracts address from URL slug', async () => {
+  // Ensure fetch is not called for this test
+  ;(global as any).fetch = async () => {
+    throw new Error('should not fetch for slug parsing test')
+  }
+
+  const url = 'https://www.zillow.com/homedetails/123-Main-St-Somecity-ST-12345/1234567_zpid/'
+  const address = await extractAddressFromUrl(url)
+  strictEqual(address, '123 Main St, Somecity, ST 12345')
+})
+
+test('extracts address from JSON-LD in HTML', async () => {
+  ;(global as any).fetch = async () => {
+    return {
+      ok: true,
+      text: async () => `
+        <html>
+          <head>
+            <script type="application/ld+json">
+              {
+                "@context": "https://schema.org",
+                "@type": "Offer",
+                "address": {
+                  "@type": "PostalAddress",
+                  "streetAddress": "456 Oak Ave",
+                  "addressLocality": "Redwood City",
+                  "addressRegion": "CA",
+                  "postalCode": "94063"
+                }
+              }
+            </script>
+          </head>
+          <body></body>
+        </html>
+      `
+    } as any
+  }
+
+  const url = 'https://example.com/listing/abc'
+  const address = await extractAddressFromUrl(url)
+  strictEqual(address, '456 Oak Ave, Redwood City, CA 94063')
+})
+
+test('throws NOT_FOUND when no address is present', async () => {
+  ;(global as any).fetch = async () => {
+    return {
+      ok: true,
+      text: async () => `<html><body><p>No address here</p></body></html>`
+    } as any
+  }
+
+  const url = 'https://example.com/listing/no-address'
+  await rejects(async () => extractAddressFromUrl(url))
+})
+
+// Restore fetch after tests
+;(global as any).fetch = originalFetch


### PR DESCRIPTION
Adds a new API endpoint and service to extract normalized addresses from listing URLs by parsing URL slugs, JSON-LD, meta tags, and page content.

---
<a href="https://cursor.com/background-agent?bcId=bc-3775d8af-86ff-4b8d-b19b-5d38e5c34ded">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3775d8af-86ff-4b8d-b19b-5d38e5c34ded">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

