### PR TITLE
Extension maps

### DIFF
--- a/src/app/api/opportunity-zones/shapes/route.ts
+++ b/src/app/api/opportunity-zones/shapes/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { PostGISOpportunityZoneService } from '@/lib/services/postgis-opportunity-zones'
 import { ContiguityAnalyzer } from '@/lib/utils/contiguity-analyzer'
+import { prisma } from '@/app/prisma'
 
 const ZONE_COLORS = [
   '#FF6B6B', // Red
@@ -16,6 +17,41 @@ const ZONE_COLORS = [
   '#85C1E9', // Light Blue
   '#82E0AA'  // Light Green
 ]
+
+// Authentication helper (shared with other endpoints)
+async function authenticateRequest(request: NextRequest) {
+  const authHeader = request.headers.get('authorization');
+
+  if (!authHeader) {
+    return null;
+  }
+
+  const token = authHeader.split(' ')[1];
+
+  if (!token) {
+    return null;
+  }
+
+  try {
+    const accessToken = await prisma.accessToken.findUnique({
+      where: { token },
+      include: { user: true },
+    });
+
+    if (!accessToken) {
+      return null;
+    }
+
+    if (accessToken.expiresAt < new Date()) {
+      return null;
+    }
+
+    return accessToken;
+  } catch (e) {
+    console.error('Error validating token:', e);
+    return null;
+  }
+}
 
 export async function GET(request: NextRequest) {
   const withCors = (res: NextResponse) => {
@@ -126,13 +162,179 @@ export async function GET(request: NextRequest) {
   }
 }
 
+export async function POST(request: NextRequest) {
+  const withCors = (res: NextResponse) => {
+    res.headers.set('Access-Control-Allow-Origin', '*')
+    res.headers.set('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
+    res.headers.set('Access-Control-Allow-Headers', 'Content-Type, Authorization, X-OZ-Extension')
+    return res
+  }
+
+  const startTime = Date.now()
+
+  try {
+    // Check for required headers
+    const authHeader = request.headers.get('authorization')
+    const extensionHeader = request.headers.get('x-oz-extension')
+
+    if (!authHeader) {
+      return withCors(NextResponse.json(
+        {
+          error: 'Missing Authorization header',
+          message: 'Bearer token is required for shape requests'
+        },
+        { status: 401 }
+      ))
+    }
+
+    if (!extensionHeader) {
+      return withCors(NextResponse.json(
+        {
+          error: 'Missing X-OZ-Extension header',
+          message: 'Extension version header is required'
+        },
+        { status: 400 }
+      ))
+    }
+
+    // Authenticate the request
+    const accessToken = await authenticateRequest(request)
+    if (!accessToken) {
+      return withCors(NextResponse.json(
+        {
+          error: 'Invalid or expired token',
+          message: 'Please provide a valid API token'
+        },
+        { status: 401 }
+      ))
+    }
+
+    // Parse request body
+    let body
+    try {
+      body = await request.json()
+    } catch (error) {
+      return withCors(NextResponse.json(
+        {
+          error: 'Invalid JSON body',
+          message: 'Request body must be valid JSON'
+        },
+        { status: 400 }
+      ))
+    }
+
+    // Validate zone_ids parameter
+    const { zone_ids } = body
+    if (!zone_ids) {
+      return withCors(NextResponse.json(
+        {
+          error: 'Missing zone_ids parameter',
+          message: 'Request body must include zone_ids array',
+          example: { zone_ids: ['06037980100', '06037980200'] }
+        },
+        { status: 400 }
+      ))
+    }
+
+    if (!Array.isArray(zone_ids)) {
+      return withCors(NextResponse.json(
+        {
+          error: 'Invalid zone_ids parameter',
+          message: 'zone_ids must be an array of strings',
+          example: { zone_ids: ['06037980100', '06037980200'] }
+        },
+        { status: 400 }
+      ))
+    }
+
+    if (zone_ids.length === 0) {
+      return withCors(NextResponse.json(
+        {
+          error: 'Empty zone_ids array',
+          message: 'zone_ids array cannot be empty'
+        },
+        { status: 400 }
+      ))
+    }
+
+    if (zone_ids.length > 50) {
+      return withCors(NextResponse.json(
+        {
+          error: 'Too many zone_ids',
+          message: 'Maximum 50 zone IDs allowed per request',
+          provided: zone_ids.length,
+          maximum: 50
+        },
+        { status: 400 }
+      ))
+    }
+
+    // Validate zone_ids format
+    const invalidZoneIds = zone_ids.filter((id: any) => typeof id !== 'string' || id.trim().length === 0)
+    if (invalidZoneIds.length > 0) {
+      return withCors(NextResponse.json(
+        {
+          error: 'Invalid zone_ids format',
+          message: 'All zone_ids must be non-empty strings',
+          invalidIds: invalidZoneIds
+        },
+        { status: 400 }
+      ))
+    }
+
+    const service = PostGISOpportunityZoneService.getInstance()
+
+    // Fetch opportunity zone shapes by zone IDs
+    const geoJsonData = await service.getShapesByZoneIds(zone_ids)
+
+    // Add color assignments to features based on contiguity
+    const coloredFeatures = ContiguityAnalyzer.assignColors(geoJsonData.features, ZONE_COLORS)
+
+    // Get contiguity statistics
+    const contiguityStats = ContiguityAnalyzer.getContiguityStats(geoJsonData.features)
+
+    const queryTime = Date.now() - startTime
+
+    const response = {
+      type: 'FeatureCollection',
+      features: coloredFeatures,
+      metadata: {
+        requestedZones: zone_ids.length,
+        foundZones: coloredFeatures.length,
+        extensionVersion: extensionHeader,
+        queryTime: `${queryTime}ms`,
+        colors: ZONE_COLORS,
+        contiguity: contiguityStats,
+        message: coloredFeatures.length === 0
+          ? 'No opportunity zones found for the provided IDs'
+          : `Found ${coloredFeatures.length}/${zone_ids.length} opportunity zones in ${contiguityStats.contiguousGroups} contiguous group(s)`
+      }
+    }
+
+    return withCors(NextResponse.json(response))
+
+  } catch (error) {
+    console.error('Error fetching opportunity zone shapes by IDs:', error)
+
+    const queryTime = Date.now() - startTime
+    return withCors(NextResponse.json(
+      {
+        error: 'Failed to fetch opportunity zone shapes',
+        details: error instanceof Error ? error.message : 'Unknown error',
+        queryTime: `${queryTime}ms`
+      },
+      { status: 500 }
+    ))
+  }
+}
+
 export async function OPTIONS() {
   return new NextResponse(null, {
     status: 204,
     headers: {
       'Access-Control-Allow-Origin': '*',
-      'Access-Control-Allow-Methods': 'GET, OPTIONS',
-      'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+      'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type, Authorization, X-OZ-Extension',
     }
   })
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -408,7 +408,7 @@ export default function HomePage() {
                     </span>
                   </div>
                   {!searchResult.error && (
-                    <Badge variant="secondary">Zone: {searchResult.tractId}</Badge>
+                    <Badge variant="secondary">Census Tract: {searchResult.tractId}</Badge>
                   )}
                 </div>
                 
@@ -430,13 +430,6 @@ export default function HomePage() {
                   </div>
                 )}
                 
-                {!searchResult.error && (
-                  <p className="mt-2 text-sm text-muted-foreground">
-                    Address: {searchResult.address}
-                    {searchResult.queryTime && ` • Query Time: ${searchResult.queryTime}`}
-                    {searchResult.method && ` • Method: ${searchResult.method}`}
-                  </p>
-                )}
               </motion.div>
             )}
 

--- a/tests/api.shapes-post.test.ts
+++ b/tests/api.shapes-post.test.ts
@@ -1,0 +1,402 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+// Mock prisma for testing shapes POST endpoint
+class MockPrisma {
+  private postGISEnabled: boolean;
+  private queryResults: any[];
+
+  constructor(postGISEnabled = true, queryResults: any[] = []) {
+    this.postGISEnabled = postGISEnabled;
+    this.queryResults = queryResults;
+  }
+
+  async $queryRaw(query: any) {
+    // Mock PostGIS extension check
+    if (query.strings[0].includes('pg_extension')) {
+      return [{ available: this.postGISEnabled }];
+    }
+
+    // Mock shapes by zone IDs query
+    if (query.strings[0].includes('WHERE geoid = ANY')) {
+      return this.queryResults;
+    }
+
+    return [];
+  }
+
+  // Mock findUnique for access token validation
+  accessToken = {
+    findUnique: ({ where }: { where: { token: string } }) => {
+      // Mock valid token
+      if (where.token === 'valid_token') {
+        return Promise.resolve({
+          id: 'token_id',
+          userId: 'user_id',
+          expiresAt: new Date(Date.now() + 3600000), // 1 hour from now
+          user: { id: 'user_id', monthlyUsageLimit: 100 }
+        });
+      }
+      // Mock expired token
+      if (where.token === 'expired_token') {
+        return Promise.resolve({
+          id: 'token_id',
+          userId: 'user_id',
+          expiresAt: new Date(Date.now() - 3600000), // 1 hour ago
+          user: { id: 'user_id' }
+        });
+      }
+      // Token not found
+      return Promise.resolve(null);
+    }
+  };
+}
+
+// Simplified PostGIS service for testing shapes functionality
+class TestPostGISService {
+  private isPostGISEnabled: boolean | null = null;
+  private prisma: MockPrisma;
+
+  constructor(mockPrisma: MockPrisma) {
+    this.prisma = mockPrisma;
+  }
+
+  async checkPostGISAvailability(): Promise<boolean> {
+    if (this.isPostGISEnabled !== null) {
+      return this.isPostGISEnabled;
+    }
+
+    try {
+      const result = await this.prisma.$queryRaw<{ available: boolean }[]>({
+        strings: ['SELECT EXISTS( SELECT 1 FROM pg_extension WHERE extname = \'postgis\' ) as available'],
+        values: []
+      });
+
+      this.isPostGISEnabled = result[0]?.available || false;
+      return this.isPostGISEnabled;
+    } catch (error) {
+      this.isPostGISEnabled = false;
+      return false;
+    }
+  }
+
+  async getShapesByZoneIds(zoneIds: string[]): Promise<{
+    type: 'FeatureCollection';
+    features: Array<{
+      type: 'Feature';
+      properties: {
+        geoid: string;
+        CENSUSTRAC: string;
+        id: string;
+        name: string;
+        state: string;
+        county: string;
+      };
+      geometry: any;
+    }>;
+  }> {
+    const isPostGISAvailable = await this.checkPostGISAvailability();
+
+    if (!isPostGISAvailable) {
+      return {
+        type: 'FeatureCollection',
+        features: []
+      };
+    }
+
+    if (!zoneIds || zoneIds.length === 0) {
+      return {
+        type: 'FeatureCollection',
+        features: []
+      };
+    }
+
+    try {
+      const result = await this.prisma.$queryRaw<{
+        geoid: string;
+        geometry: string;
+      }[]>({
+        strings: ['SELECT geoid, ST_AsGeoJSON(COALESCE("simplifiedGeom", "originalGeom")) as geometry FROM "OpportunityZone" WHERE geoid = ANY($1::text[]) ORDER BY geoid'],
+        values: [zoneIds]
+      });
+
+      const features = result.map(row => ({
+        type: 'Feature' as const,
+        properties: {
+          geoid: row.geoid,
+          CENSUSTRAC: row.geoid,
+          id: row.geoid,
+          name: row.geoid,
+          state: 'California',
+          county: 'Los Angeles'
+        },
+        geometry: JSON.parse(row.geometry)
+      }));
+
+      return {
+        type: 'FeatureCollection',
+        features
+      };
+    } catch (error) {
+      return {
+        type: 'FeatureCollection',
+        features: []
+      };
+    }
+  }
+}
+
+// Mock authentication function
+async function mockAuthenticateRequest(token: string | null, mockPrisma: MockPrisma) {
+  if (!token) {
+    return null;
+  }
+
+  return await mockPrisma.accessToken.findUnique({ where: { token } });
+}
+
+test('PostGIS getShapesByZoneIds - successful retrieval', async () => {
+  const mockGeometry = '{"type":"Polygon","coordinates":[[[-118.5,34.0],[-118.4,34.0],[-118.4,34.1],[-118.5,34.1],[-118.5,34.0]]]}';
+  const mockPrisma = new MockPrisma(true, [
+    { geoid: '06037980100', geometry: mockGeometry },
+    { geoid: '06037980200', geometry: mockGeometry }
+  ]);
+  const service = new TestPostGISService(mockPrisma);
+
+  const result = await service.getShapesByZoneIds(['06037980100', '06037980200']);
+
+  assert.strictEqual(result.type, 'FeatureCollection', 'Should return FeatureCollection');
+  assert.strictEqual(result.features.length, 2, 'Should return 2 features');
+  assert.strictEqual(result.features[0].properties.geoid, '06037980100', 'Should have correct geoid');
+  assert.strictEqual(result.features[0].properties.CENSUSTRAC, '06037980100', 'Should map geoid to CENSUSTRAC');
+  assert.strictEqual(result.features[0].properties.id, '06037980100', 'Should map geoid to id');
+  assert.strictEqual(result.features[0].type, 'Feature', 'Should be Feature type');
+});
+
+test('PostGIS getShapesByZoneIds - empty zone_ids array', async () => {
+  const mockPrisma = new MockPrisma(true, []);
+  const service = new TestPostGISService(mockPrisma);
+
+  const result = await service.getShapesByZoneIds([]);
+
+  assert.strictEqual(result.type, 'FeatureCollection', 'Should return FeatureCollection');
+  assert.strictEqual(result.features.length, 0, 'Should return no features for empty array');
+});
+
+test('PostGIS getShapesByZoneIds - PostGIS not available', async () => {
+  const mockPrisma = new MockPrisma(false); // PostGIS disabled
+  const service = new TestPostGISService(mockPrisma);
+
+  const result = await service.getShapesByZoneIds(['06037980100']);
+
+  assert.strictEqual(result.type, 'FeatureCollection', 'Should return FeatureCollection');
+  assert.strictEqual(result.features.length, 0, 'Should return no features when PostGIS unavailable');
+});
+
+test('PostGIS getShapesByZoneIds - partial results', async () => {
+  const mockGeometry = '{"type":"Polygon","coordinates":[[[-118.5,34.0],[-118.4,34.0],[-118.4,34.1],[-118.5,34.1],[-118.5,34.0]]]}';
+  const mockPrisma = new MockPrisma(true, [
+    { geoid: '06037980100', geometry: mockGeometry }
+    // Only one result for two requested zones
+  ]);
+  const service = new TestPostGISService(mockPrisma);
+
+  const result = await service.getShapesByZoneIds(['06037980100', '06037980200']);
+
+  assert.strictEqual(result.type, 'FeatureCollection', 'Should return FeatureCollection');
+  assert.strictEqual(result.features.length, 1, 'Should return only found features');
+  assert.strictEqual(result.features[0].properties.geoid, '06037980100', 'Should return found zone');
+});
+
+test('PostGIS getShapesByZoneIds - property mapping validation', async () => {
+  const mockGeometry = '{"type":"Polygon","coordinates":[[[-118.5,34.0],[-118.4,34.0],[-118.4,34.1],[-118.5,34.1],[-118.5,34.0]]]}';
+  const mockPrisma = new MockPrisma(true, [
+    { geoid: '06037980100', geometry: mockGeometry }
+  ]);
+  const service = new TestPostGISService(mockPrisma);
+
+  const result = await service.getShapesByZoneIds(['06037980100']);
+
+  const feature = result.features[0];
+  const props = feature.properties;
+
+  // Validate all required properties for Chrome extension
+  assert.strictEqual(props.geoid, '06037980100', 'Should have geoid property');
+  assert.strictEqual(props.CENSUSTRAC, '06037980100', 'Should have CENSUSTRAC property');
+  assert.strictEqual(props.id, '06037980100', 'Should have id property');
+  assert.strictEqual(typeof props.name, 'string', 'Should have name property as string');
+  assert.strictEqual(typeof props.state, 'string', 'Should have state property as string');
+  assert.strictEqual(typeof props.county, 'string', 'Should have county property as string');
+});
+
+test('Authentication - valid token', async () => {
+  const mockPrisma = new MockPrisma();
+
+  const result = await mockAuthenticateRequest('valid_token', mockPrisma);
+
+  assert.ok(result, 'Should return access token for valid token');
+  assert.strictEqual(result.userId, 'user_id', 'Should have correct user ID');
+  assert.ok(result.expiresAt > new Date(), 'Should not be expired');
+});
+
+test('Authentication - expired token', async () => {
+  const mockPrisma = new MockPrisma();
+
+  const result = await mockAuthenticateRequest('expired_token', mockPrisma);
+
+  assert.ok(result, 'Should find expired token in database');
+  assert.ok(result.expiresAt < new Date(), 'Should be expired');
+});
+
+test('Authentication - invalid token', async () => {
+  const mockPrisma = new MockPrisma();
+
+  const result = await mockAuthenticateRequest('invalid_token', mockPrisma);
+
+  assert.strictEqual(result, null, 'Should return null for invalid token');
+});
+
+test('Authentication - missing token', async () => {
+  const mockPrisma = new MockPrisma();
+
+  const result = await mockAuthenticateRequest(null, mockPrisma);
+
+  assert.strictEqual(result, null, 'Should return null for missing token');
+});
+
+// Test zone_ids validation logic
+test('Zone IDs validation - valid array', () => {
+  const zoneIds = ['06037980100', '06037980200', '06037980300'];
+
+  // Test array validation
+  assert.ok(Array.isArray(zoneIds), 'Should be an array');
+  assert.ok(zoneIds.length > 0, 'Should not be empty');
+  assert.ok(zoneIds.length <= 50, 'Should not exceed maximum');
+
+  // Test string validation
+  const invalidIds = zoneIds.filter(id => typeof id !== 'string' || id.trim().length === 0);
+  assert.strictEqual(invalidIds.length, 0, 'All IDs should be non-empty strings');
+});
+
+test('Zone IDs validation - invalid formats', () => {
+  const testCases = [
+    { input: null, name: 'null' },
+    { input: undefined, name: 'undefined' },
+    { input: 'string', name: 'string instead of array' },
+    { input: 123, name: 'number instead of array' },
+    { input: [], name: 'empty array' },
+    { input: [''], name: 'empty string in array' },
+    { input: ['valid', null], name: 'null in array' },
+    { input: ['valid', 123], name: 'number in array' },
+    { input: Array(51).fill('zone'), name: 'too many zones' }
+  ];
+
+  testCases.forEach(({ input, name }) => {
+    // Simulate validation logic
+    let isValid = true;
+    let errorReason = '';
+
+    if (!input) {
+      isValid = false;
+      errorReason = 'Missing zone_ids';
+    } else if (!Array.isArray(input)) {
+      isValid = false;
+      errorReason = 'Not an array';
+    } else if (input.length === 0) {
+      isValid = false;
+      errorReason = 'Empty array';
+    } else if (input.length > 50) {
+      isValid = false;
+      errorReason = 'Too many zones';
+    } else {
+      const invalidIds = input.filter(id => typeof id !== 'string' || id.trim().length === 0);
+      if (invalidIds.length > 0) {
+        isValid = false;
+        errorReason = 'Invalid ID format';
+      }
+    }
+
+    assert.strictEqual(isValid, false, `Should be invalid for ${name}: ${errorReason}`);
+  });
+});
+
+test('Zone IDs validation - boundary conditions', () => {
+  // Test exactly 50 zones (maximum allowed)
+  const maxZones = Array(50).fill(0).map((_, i) => `zone${i.toString().padStart(3, '0')}`);
+  assert.strictEqual(maxZones.length, 50, 'Should allow exactly 50 zones');
+
+  const invalidIds = maxZones.filter(id => typeof id !== 'string' || id.trim().length === 0);
+  assert.strictEqual(invalidIds.length, 0, 'All max zones should be valid strings');
+
+  // Test 51 zones (over limit)
+  const overLimitZones = Array(51).fill(0).map((_, i) => `zone${i}`);
+  assert.ok(overLimitZones.length > 50, 'Should exceed maximum');
+});
+
+test('GeoJSON geometry parsing - valid polygon', () => {
+  const mockGeometry = '{"type":"Polygon","coordinates":[[[-118.5,34.0],[-118.4,34.0],[-118.4,34.1],[-118.5,34.1],[-118.5,34.0]]]}';
+
+  let parsedGeometry;
+  assert.doesNotThrow(() => {
+    parsedGeometry = JSON.parse(mockGeometry);
+  }, 'Should parse valid GeoJSON');
+
+  assert.strictEqual(parsedGeometry.type, 'Polygon', 'Should be Polygon type');
+  assert.ok(Array.isArray(parsedGeometry.coordinates), 'Should have coordinates array');
+  assert.ok(parsedGeometry.coordinates[0].length >= 4, 'Should have minimum coordinate points for polygon');
+});
+
+test('Error handling - malformed geometry', () => {
+  const invalidGeometry = '{"type":"Polygon","coordinates":invalid}';
+
+  assert.throws(() => {
+    JSON.parse(invalidGeometry);
+  }, 'Should throw error for malformed geometry');
+});
+
+test('Response format validation - Chrome extension compatibility', () => {
+  const mockResponse = {
+    type: 'FeatureCollection',
+    features: [
+      {
+        type: 'Feature',
+        properties: {
+          geoid: '06037980100',
+          CENSUSTRAC: '06037980100',
+          id: '06037980100',
+          name: '06037980100',
+          state: 'California',
+          county: 'Los Angeles'
+        },
+        geometry: {
+          type: 'Polygon',
+          coordinates: [[[-118.5,34.0],[-118.4,34.0],[-118.4,34.1],[-118.5,34.1],[-118.5,34.0]]]
+        }
+      }
+    ],
+    metadata: {
+      requestedZones: 1,
+      foundZones: 1,
+      extensionVersion: '1.0.0',
+      queryTime: '50ms'
+    }
+  };
+
+  // Validate response structure
+  assert.strictEqual(mockResponse.type, 'FeatureCollection', 'Should be FeatureCollection');
+  assert.ok(Array.isArray(mockResponse.features), 'Should have features array');
+  assert.ok(mockResponse.metadata, 'Should have metadata object');
+
+  // Validate feature structure
+  const feature = mockResponse.features[0];
+  assert.strictEqual(feature.type, 'Feature', 'Feature should have correct type');
+  assert.ok(feature.properties, 'Feature should have properties');
+  assert.ok(feature.geometry, 'Feature should have geometry');
+
+  // Validate Chrome extension required properties
+  const props = feature.properties;
+  assert.ok(props.CENSUSTRAC, 'Should have CENSUSTRAC for Chrome extension');
+  assert.ok(props.id, 'Should have id for Chrome extension');
+  assert.strictEqual(props.CENSUSTRAC, props.geoid, 'CENSUSTRAC should match geoid');
+  assert.strictEqual(props.id, props.geoid, 'id should match geoid');
+});

--- a/tests/chrome-extension.shapes.e2e.test.ts
+++ b/tests/chrome-extension.shapes.e2e.test.ts
@@ -1,0 +1,492 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+// Mock HTTP request/response for integration testing
+class MockRequest {
+  public method: string;
+  public headers: Map<string, string>;
+  public body: any;
+  public nextUrl: { searchParams: URLSearchParams };
+
+  constructor(method: string, headers: Record<string, string> = {}, body: any = null) {
+    this.method = method;
+    this.headers = new Map(Object.entries(headers));
+    this.body = body;
+    this.nextUrl = { searchParams: new URLSearchParams() };
+  }
+
+  headers_get(name: string): string | null {
+    return this.headers.get(name.toLowerCase()) || null;
+  }
+
+  async json() {
+    if (this.body && typeof this.body === 'object') {
+      return this.body;
+    }
+    throw new Error('Invalid JSON body');
+  }
+}
+
+class MockResponse {
+  public status: number;
+  public headers: Map<string, string>;
+  public body: any;
+
+  constructor(body: any, options: { status: number } = { status: 200 }) {
+    this.status = options.status;
+    this.headers = new Map();
+    this.body = body;
+  }
+
+  static json(body: any, options: { status: number } = { status: 200 }) {
+    return new MockResponse(body, options);
+  }
+
+  headers_set(name: string, value: string) {
+    this.headers.set(name.toLowerCase(), value);
+    return this;
+  }
+}
+
+// Mock the shapes endpoint POST handler logic
+async function mockShapesPOSTHandler(request: MockRequest): Promise<MockResponse> {
+  const withCors = (res: MockResponse) => {
+    res.headers_set('Access-Control-Allow-Origin', '*');
+    res.headers_set('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+    res.headers_set('Access-Control-Allow-Headers', 'Content-Type, Authorization, X-OZ-Extension');
+    return res;
+  };
+
+  try {
+    // Check for required headers
+    const authHeader = request.headers_get('authorization');
+    const extensionHeader = request.headers_get('x-oz-extension');
+
+    if (!authHeader) {
+      return withCors(MockResponse.json(
+        {
+          error: 'Missing Authorization header',
+          message: 'Bearer token is required for shape requests'
+        },
+        { status: 401 }
+      ));
+    }
+
+    if (!extensionHeader) {
+      return withCors(MockResponse.json(
+        {
+          error: 'Missing X-OZ-Extension header',
+          message: 'Extension version header is required'
+        },
+        { status: 400 }
+      ));
+    }
+
+    // Simple token validation
+    const token = authHeader.split(' ')[1];
+    if (!token || token !== 'valid_chrome_token') {
+      return withCors(MockResponse.json(
+        {
+          error: 'Invalid or expired token',
+          message: 'Please provide a valid API token'
+        },
+        { status: 401 }
+      ));
+    }
+
+    // Parse request body
+    let body;
+    try {
+      body = await request.json();
+    } catch (error) {
+      return withCors(MockResponse.json(
+        {
+          error: 'Invalid JSON body',
+          message: 'Request body must be valid JSON'
+        },
+        { status: 400 }
+      ));
+    }
+
+    // Validate zone_ids parameter
+    const { zone_ids } = body;
+    if (!zone_ids) {
+      return withCors(MockResponse.json(
+        {
+          error: 'Missing zone_ids parameter',
+          message: 'Request body must include zone_ids array',
+          example: { zone_ids: ['06037980100', '06037980200'] }
+        },
+        { status: 400 }
+      ));
+    }
+
+    if (!Array.isArray(zone_ids)) {
+      return withCors(MockResponse.json(
+        {
+          error: 'Invalid zone_ids parameter',
+          message: 'zone_ids must be an array of strings',
+          example: { zone_ids: ['06037980100', '06037980200'] }
+        },
+        { status: 400 }
+      ));
+    }
+
+    if (zone_ids.length === 0) {
+      return withCors(MockResponse.json(
+        {
+          error: 'Empty zone_ids array',
+          message: 'zone_ids array cannot be empty'
+        },
+        { status: 400 }
+      ));
+    }
+
+    if (zone_ids.length > 50) {
+      return withCors(MockResponse.json(
+        {
+          error: 'Too many zone_ids',
+          message: 'Maximum 50 zone IDs allowed per request',
+          provided: zone_ids.length,
+          maximum: 50
+        },
+        { status: 400 }
+      ));
+    }
+
+    // Validate zone_ids format
+    const invalidZoneIds = zone_ids.filter((id: any) => typeof id !== 'string' || id.trim().length === 0);
+    if (invalidZoneIds.length > 0) {
+      return withCors(MockResponse.json(
+        {
+          error: 'Invalid zone_ids format',
+          message: 'All zone_ids must be non-empty strings',
+          invalidIds: invalidZoneIds
+        },
+        { status: 400 }
+      ));
+    }
+
+    // Mock successful response with sample data
+    const mockFeatures = zone_ids.slice(0, 2).map((zoneId: string) => ({
+      type: 'Feature',
+      properties: {
+        geoid: zoneId,
+        CENSUSTRAC: zoneId, // Chrome extension expects this
+        id: zoneId, // Chrome extension expects this
+        name: zoneId,
+        state: 'California',
+        county: 'Los Angeles',
+        color: '#FF6B6B' // Added by contiguity analyzer
+      },
+      geometry: {
+        type: 'Polygon',
+        coordinates: [[[-118.5, 34.0], [-118.4, 34.0], [-118.4, 34.1], [-118.5, 34.1], [-118.5, 34.0]]]
+      }
+    }));
+
+    const response = {
+      type: 'FeatureCollection',
+      features: mockFeatures,
+      metadata: {
+        requestedZones: zone_ids.length,
+        foundZones: mockFeatures.length,
+        extensionVersion: extensionHeader,
+        queryTime: '25ms',
+        colors: ['#FF6B6B', '#4ECDC4', '#45B7D1'],
+        contiguity: {
+          contiguousGroups: 1,
+          isolatedZones: 0,
+          largestGroupSize: mockFeatures.length
+        },
+        message: `Found ${mockFeatures.length}/${zone_ids.length} opportunity zones in 1 contiguous group(s)`
+      }
+    };
+
+    return withCors(MockResponse.json(response));
+
+  } catch (error) {
+    return withCors(MockResponse.json(
+      {
+        error: 'Failed to fetch opportunity zone shapes',
+        details: error instanceof Error ? error.message : 'Unknown error',
+        queryTime: '5ms'
+      },
+      { status: 500 }
+    ));
+  }
+}
+
+// Integration tests simulating Chrome extension requests
+test('Chrome Extension Integration - successful shapes request', async () => {
+  const request = new MockRequest('POST', {
+    'authorization': 'Bearer valid_chrome_token',
+    'x-oz-extension': '1.0.0',
+    'content-type': 'application/json'
+  }, {
+    zone_ids: ['06037980100', '06037980200']
+  });
+
+  const response = await mockShapesPOSTHandler(request);
+
+  assert.strictEqual(response.status, 200, 'Should return 200 status');
+
+  const responseData = response.body;
+  assert.strictEqual(responseData.type, 'FeatureCollection', 'Should return FeatureCollection');
+  assert.strictEqual(responseData.features.length, 2, 'Should return 2 features');
+
+  // Validate Chrome extension compatibility
+  const feature = responseData.features[0];
+  assert.ok(feature.properties.CENSUSTRAC, 'Should have CENSUSTRAC property for Chrome extension');
+  assert.ok(feature.properties.id, 'Should have id property for Chrome extension');
+  assert.strictEqual(feature.properties.CENSUSTRAC, feature.properties.geoid, 'CENSUSTRAC should match geoid');
+  assert.strictEqual(feature.properties.id, feature.properties.geoid, 'id should match geoid');
+
+  // Validate CORS headers
+  assert.strictEqual(response.headers.get('access-control-allow-origin'), '*', 'Should have CORS origin header');
+  assert.ok(response.headers.get('access-control-allow-methods')?.includes('POST'), 'Should allow POST method');
+});
+
+test('Chrome Extension Integration - missing authorization header', async () => {
+  const request = new MockRequest('POST', {
+    'x-oz-extension': '1.0.0',
+    'content-type': 'application/json'
+  }, {
+    zone_ids: ['06037980100']
+  });
+
+  const response = await mockShapesPOSTHandler(request);
+
+  assert.strictEqual(response.status, 401, 'Should return 401 for missing auth');
+  assert.strictEqual(response.body.error, 'Missing Authorization header', 'Should have correct error message');
+});
+
+test('Chrome Extension Integration - missing extension header', async () => {
+  const request = new MockRequest('POST', {
+    'authorization': 'Bearer valid_chrome_token',
+    'content-type': 'application/json'
+  }, {
+    zone_ids: ['06037980100']
+  });
+
+  const response = await mockShapesPOSTHandler(request);
+
+  assert.strictEqual(response.status, 400, 'Should return 400 for missing extension header');
+  assert.strictEqual(response.body.error, 'Missing X-OZ-Extension header', 'Should have correct error message');
+});
+
+test('Chrome Extension Integration - invalid token', async () => {
+  const request = new MockRequest('POST', {
+    'authorization': 'Bearer invalid_token',
+    'x-oz-extension': '1.0.0',
+    'content-type': 'application/json'
+  }, {
+    zone_ids: ['06037980100']
+  });
+
+  const response = await mockShapesPOSTHandler(request);
+
+  assert.strictEqual(response.status, 401, 'Should return 401 for invalid token');
+  assert.strictEqual(response.body.error, 'Invalid or expired token', 'Should have correct error message');
+});
+
+test('Chrome Extension Integration - malformed JSON body', async () => {
+  const request = new MockRequest('POST', {
+    'authorization': 'Bearer valid_chrome_token',
+    'x-oz-extension': '1.0.0',
+    'content-type': 'application/json'
+  }, 'invalid json');
+
+  const response = await mockShapesPOSTHandler(request);
+
+  assert.strictEqual(response.status, 400, 'Should return 400 for malformed JSON');
+  assert.strictEqual(response.body.error, 'Invalid JSON body', 'Should have correct error message');
+});
+
+test('Chrome Extension Integration - missing zone_ids', async () => {
+  const request = new MockRequest('POST', {
+    'authorization': 'Bearer valid_chrome_token',
+    'x-oz-extension': '1.0.0',
+    'content-type': 'application/json'
+  }, {
+    // Missing zone_ids
+  });
+
+  const response = await mockShapesPOSTHandler(request);
+
+  assert.strictEqual(response.status, 400, 'Should return 400 for missing zone_ids');
+  assert.strictEqual(response.body.error, 'Missing zone_ids parameter', 'Should have correct error message');
+  assert.ok(response.body.example, 'Should provide usage example');
+});
+
+test('Chrome Extension Integration - invalid zone_ids type', async () => {
+  const request = new MockRequest('POST', {
+    'authorization': 'Bearer valid_chrome_token',
+    'x-oz-extension': '1.0.0',
+    'content-type': 'application/json'
+  }, {
+    zone_ids: 'not_an_array'
+  });
+
+  const response = await mockShapesPOSTHandler(request);
+
+  assert.strictEqual(response.status, 400, 'Should return 400 for invalid zone_ids type');
+  assert.strictEqual(response.body.error, 'Invalid zone_ids parameter', 'Should have correct error message');
+});
+
+test('Chrome Extension Integration - empty zone_ids array', async () => {
+  const request = new MockRequest('POST', {
+    'authorization': 'Bearer valid_chrome_token',
+    'x-oz-extension': '1.0.0',
+    'content-type': 'application/json'
+  }, {
+    zone_ids: []
+  });
+
+  const response = await mockShapesPOSTHandler(request);
+
+  assert.strictEqual(response.status, 400, 'Should return 400 for empty zone_ids');
+  assert.strictEqual(response.body.error, 'Empty zone_ids array', 'Should have correct error message');
+});
+
+test('Chrome Extension Integration - too many zone_ids', async () => {
+  const tooManyZones = Array(51).fill(0).map((_, i) => `zone${i}`);
+
+  const request = new MockRequest('POST', {
+    'authorization': 'Bearer valid_chrome_token',
+    'x-oz-extension': '1.0.0',
+    'content-type': 'application/json'
+  }, {
+    zone_ids: tooManyZones
+  });
+
+  const response = await mockShapesPOSTHandler(request);
+
+  assert.strictEqual(response.status, 400, 'Should return 400 for too many zone_ids');
+  assert.strictEqual(response.body.error, 'Too many zone_ids', 'Should have correct error message');
+  assert.strictEqual(response.body.provided, 51, 'Should report provided count');
+  assert.strictEqual(response.body.maximum, 50, 'Should report maximum allowed');
+});
+
+test('Chrome Extension Integration - invalid zone_id formats', async () => {
+  const request = new MockRequest('POST', {
+    'authorization': 'Bearer valid_chrome_token',
+    'x-oz-extension': '1.0.0',
+    'content-type': 'application/json'
+  }, {
+    zone_ids: ['valid_zone', '', null, 123]
+  });
+
+  const response = await mockShapesPOSTHandler(request);
+
+  assert.strictEqual(response.status, 400, 'Should return 400 for invalid zone_id formats');
+  assert.strictEqual(response.body.error, 'Invalid zone_ids format', 'Should have correct error message');
+  assert.ok(Array.isArray(response.body.invalidIds), 'Should report invalid IDs');
+});
+
+test('Chrome Extension Integration - response format validation', async () => {
+  const request = new MockRequest('POST', {
+    'authorization': 'Bearer valid_chrome_token',
+    'x-oz-extension': '1.2.3',
+    'content-type': 'application/json'
+  }, {
+    zone_ids: ['06037980100', '06037980200', '06037980300']
+  });
+
+  const response = await mockShapesPOSTHandler(request);
+
+  assert.strictEqual(response.status, 200, 'Should return 200 status');
+
+  const data = response.body;
+
+  // Validate GeoJSON structure
+  assert.strictEqual(data.type, 'FeatureCollection', 'Should be FeatureCollection');
+  assert.ok(Array.isArray(data.features), 'Should have features array');
+
+  // Validate metadata
+  assert.ok(data.metadata, 'Should have metadata');
+  assert.strictEqual(data.metadata.requestedZones, 3, 'Should track requested zones count');
+  assert.strictEqual(data.metadata.foundZones, 2, 'Should track found zones count');
+  assert.strictEqual(data.metadata.extensionVersion, '1.2.3', 'Should include extension version');
+  assert.ok(data.metadata.queryTime, 'Should include query time');
+  assert.ok(data.metadata.colors, 'Should include color palette');
+  assert.ok(data.metadata.contiguity, 'Should include contiguity stats');
+
+  // Validate features structure for Chrome extension
+  data.features.forEach((feature: any, index: number) => {
+    assert.strictEqual(feature.type, 'Feature', `Feature ${index} should be Feature type`);
+    assert.ok(feature.properties, `Feature ${index} should have properties`);
+    assert.ok(feature.geometry, `Feature ${index} should have geometry`);
+
+    // Chrome extension required properties
+    const props = feature.properties;
+    assert.ok(props.geoid, `Feature ${index} should have geoid`);
+    assert.ok(props.CENSUSTRAC, `Feature ${index} should have CENSUSTRAC for Chrome extension`);
+    assert.ok(props.id, `Feature ${index} should have id for Chrome extension`);
+    assert.strictEqual(props.CENSUSTRAC, props.geoid, `Feature ${index} CENSUSTRAC should match geoid`);
+    assert.strictEqual(props.id, props.geoid, `Feature ${index} id should match geoid`);
+
+    // Geometry validation
+    assert.strictEqual(feature.geometry.type, 'Polygon', `Feature ${index} should have Polygon geometry`);
+    assert.ok(Array.isArray(feature.geometry.coordinates), `Feature ${index} should have coordinates array`);
+  });
+});
+
+test('Chrome Extension Integration - CORS headers validation', async () => {
+  const request = new MockRequest('POST', {
+    'authorization': 'Bearer valid_chrome_token',
+    'x-oz-extension': '1.0.0',
+    'content-type': 'application/json'
+  }, {
+    zone_ids: ['06037980100']
+  });
+
+  const response = await mockShapesPOSTHandler(request);
+
+  // Validate CORS headers are present
+  assert.strictEqual(response.headers.get('access-control-allow-origin'), '*', 'Should allow all origins');
+
+  const allowedMethods = response.headers.get('access-control-allow-methods');
+  assert.ok(allowedMethods?.includes('POST'), 'Should allow POST method');
+  assert.ok(allowedMethods?.includes('GET'), 'Should allow GET method');
+  assert.ok(allowedMethods?.includes('OPTIONS'), 'Should allow OPTIONS method');
+
+  const allowedHeaders = response.headers.get('access-control-allow-headers');
+  assert.ok(allowedHeaders?.includes('Content-Type'), 'Should allow Content-Type header');
+  assert.ok(allowedHeaders?.includes('Authorization'), 'Should allow Authorization header');
+  assert.ok(allowedHeaders?.includes('X-OZ-Extension'), 'Should allow X-OZ-Extension header');
+});
+
+test('Chrome Extension Integration - single zone request', async () => {
+  const request = new MockRequest('POST', {
+    'authorization': 'Bearer valid_chrome_token',
+    'x-oz-extension': '1.0.0',
+    'content-type': 'application/json'
+  }, {
+    zone_ids: ['06037980100']
+  });
+
+  const response = await mockShapesPOSTHandler(request);
+
+  assert.strictEqual(response.status, 200, 'Should handle single zone request');
+  assert.strictEqual(response.body.features.length, 1, 'Should return single feature');
+  assert.strictEqual(response.body.metadata.requestedZones, 1, 'Should track single requested zone');
+  assert.strictEqual(response.body.metadata.foundZones, 1, 'Should track single found zone');
+});
+
+test('Chrome Extension Integration - maximum allowed zones', async () => {
+  const maxZones = Array(50).fill(0).map((_, i) => `zone${i.toString().padStart(3, '0')}`);
+
+  const request = new MockRequest('POST', {
+    'authorization': 'Bearer valid_chrome_token',
+    'x-oz-extension': '1.0.0',
+    'content-type': 'application/json'
+  }, {
+    zone_ids: maxZones
+  });
+
+  const response = await mockShapesPOSTHandler(request);
+
+  assert.strictEqual(response.status, 200, 'Should handle maximum allowed zones');
+  assert.strictEqual(response.body.metadata.requestedZones, 50, 'Should track 50 requested zones');
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a new authenticated POST endpoint for retrieving opportunity zone shapes by zone IDs, updates service to support ID-based queries, expands CORS, tweaks UI label, and adds unit/e2e tests (incl. Chrome extension flows).
> 
> - **API**:
>   - **POST `src/app/api/opportunity-zones/shapes/route.ts`**: New authenticated endpoint accepting `zone_ids` with strict validation; returns colored GeoJSON with contiguity stats and metadata; requires `Authorization` and `X-OZ-Extension` headers; adds shared token auth; expands CORS to include `POST` and `X-OZ-Extension`.
>   - **OPTIONS**: Allow `GET, POST, OPTIONS` and new headers.
> - **Service**:
>   - **`PostGISOpportunityZoneService.getShapesByZoneIds`**: Query shapes by `geoid[]`, map required properties (`geoid`, `CENSUSTRAC`, `id`, etc.), parse geometry, return FeatureCollection.
> - **Frontend**:
>   - UI copy tweak in results badge: `Zone` → `Census Tract`; remove ancillary address/method line.
> - **Tests**:
>   - Add unit tests for ID-based shapes retrieval, auth/token cases, validation, and GeoJSON parsing.
>   - Add e2e-style tests simulating Chrome extension requests, validating CORS, headers, response shape, and error cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 927ec683da47bcdc32afdbb18b17d88315ae4aba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->